### PR TITLE
Removed wrong import from 'url' package

### DIFF
--- a/src/features/pagination/__test__/usePagination.test.tsx
+++ b/src/features/pagination/__test__/usePagination.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { act, renderHook } from '@testing-library/react'
 import { throws } from 'assert'
 import { createMemoryHistory, type History } from 'history'
-import { URLSearchParams } from 'url'
 import { usePagination } from '../hooks/usePagination'
 import { TestingRouterWrapper } from '@/utils/testing.utils'
 


### PR DESCRIPTION
This import should occur from the global namespace. This fixes a potentially broken test