### PR TITLE
Fix Link as button props types

### DIFF
--- a/src/features/router/components/Link.tsx
+++ b/src/features/router/components/Link.tsx
@@ -34,7 +34,7 @@ export function generateTypedLink<TRoutes extends Routes>(
       (
         | ({ as?: 'link' } & Omit<MUILinkProps<typeof RRDLink>, 'component' | 'to' | 'href'>)
         | ({ as: 'button' } & Omit<
-            MUIButtonProps,
+            MUIButtonProps<'a'>,
             'onClick' | 'href' | 'to' | 'LinkComponent' | 'component'
           >)
       ),


### PR DESCRIPTION
This bug was discovered by trying to insert the `target` prop in the Link component with the as prop set to "button", and receiving a type error. This PR specified to`ButtonProps`'s MUI type that we need the `anchor` tag props.
This PR fixes the props typing.