### PR TITLE
Mixpanel identifier update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pagopa/interop-fe-commons",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pagopa/interop-fe-commons",
-      "version": "1.3.1",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.22.17",

--- a/src/features/tracking/__tests__/tracking.test.ts
+++ b/src/features/tracking/__tests__/tracking.test.ts
@@ -129,6 +129,19 @@ describe('initTracking', () => {
     expect(mixpanelTrackSpy).not.toHaveBeenCalled()
   })
 
+  it('should  call trackEvent with the default props if passed', () => {
+    vi.spyOn(trackingUtils, 'areCookiesAccepted').mockReturnValue(true)
+    const defaultProp = { defaultProp: 'test' }
+
+    const { trackEvent } = initTracking<TrackingEvent>({
+      ...config,
+      getDefaultProps: () => defaultProp,
+    })
+
+    trackEvent('testEvent', { test: 'test' })
+    expect(mixpanelTrackSpy).toHaveBeenCalledWith('testEvent', { test: 'test', ...defaultProp })
+  })
+
   it('should call mixpanel.track_pageview function on page view', () => {
     vi.spyOn(trackingUtils, 'areCookiesAccepted').mockReturnValue(true)
     const { useTrackPageViewEvent } = initTracking<TrackingEvent>(config)
@@ -192,5 +205,21 @@ describe('initTracking', () => {
     renderHook(() => useTrackPageViewEvent('testEvent', { test: undefined }))
 
     expect(mixpanelTrackPageViewSpy).not.toHaveBeenCalled()
+  })
+
+  it('should call mixpanel.track_pageview function with the passed default props', () => {
+    vi.spyOn(trackingUtils, 'areCookiesAccepted').mockReturnValue(true)
+    const defaultProp = { defaultProp: 'test' }
+    const { useTrackPageViewEvent } = initTracking<TrackingEvent>({
+      ...config,
+      getDefaultProps: () => defaultProp,
+    })
+
+    renderHook(() => useTrackPageViewEvent('testEvent', { test: 'test' }))
+
+    expect(mixpanelTrackPageViewSpy).toHaveBeenCalledWith(
+      { test: 'test', ...defaultProp },
+      { event_name: 'testEvent' }
+    )
   })
 })


### PR DESCRIPTION
Added:
- `getDefaultProps` option, that let's us specify default mixpanel data to send on each tracking call;
- `setMixpanelIdentifier`, calls `mixpanel.setIdentifier`;
- `resetMixpanel` calls `mixpanel.reset`