### PR TITLE
feat: count chip inside multi-select filter input (PIN-9840)

### DIFF
--- a/src/features/filters/__tests__/Filters.test.tsx
+++ b/src/features/filters/__tests__/Filters.test.tsx
@@ -206,13 +206,11 @@ describe('Filters component', () => {
       />
     )
 
+    // Multi-select filters are represented by the count chip inside the input,
+    // so only non-multi-select active filters produce removable chips in the summary row.
     const activeFilterChip = screen.getAllByTestId('CancelIcon')[0]
     fireEvent.click(activeFilterChip)
-    expect(onRemoveActiveFilterFn).toBeCalledWith(
-      'autocomplete-multiple',
-      'multiple-field',
-      'option-1'
-    )
+    expect(onRemoveActiveFilterFn).toBeCalledWith('freetext', 'single-field', 'test-value')
   })
 
   it('should clear filters on remove filters button click', async () => {

--- a/src/features/filters/__tests__/__snapshots__/Filters.test.tsx.snap
+++ b/src/features/filters/__tests__/__snapshots__/Filters.test.tsx.snap
@@ -406,76 +406,6 @@ exports[`Filters component > matches the snapshot with more than one active filt
         <span
           className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
         >
-          Option1
-        </span>
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-deleteIcon MuiChip-deleteIconMedium MuiChip-deleteIconColorDefault MuiChip-deleteIconFilledColorDefault css-i4bv87-MuiSvgIcon-root"
-          data-testid="CancelIcon"
-          focusable="false"
-          onClick={[Function]}
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </div>
-      <div
-        className="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-filledDefault css-1mywu95-MuiButtonBase-root-MuiChip-root"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="button"
-        tabIndex={0}
-      >
-        <span
-          className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-        >
-          Option2
-        </span>
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-deleteIcon MuiChip-deleteIconMedium MuiChip-deleteIconColorDefault MuiChip-deleteIconFilledColorDefault css-i4bv87-MuiSvgIcon-root"
-          data-testid="CancelIcon"
-          focusable="false"
-          onClick={[Function]}
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </div>
-      <div
-        className="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-filledDefault css-1mywu95-MuiButtonBase-root-MuiChip-root"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="button"
-        tabIndex={0}
-      >
-        <span
-          className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-        >
           Test
         </span>
         <svg
@@ -927,76 +857,6 @@ exports[`Filters component > matches the snapshot with more than one active filt
         <span
           className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
         >
-          Option1
-        </span>
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-deleteIcon MuiChip-deleteIconMedium MuiChip-deleteIconColorDefault MuiChip-deleteIconFilledColorDefault css-i4bv87-MuiSvgIcon-root"
-          data-testid="CancelIcon"
-          focusable="false"
-          onClick={[Function]}
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </div>
-      <div
-        className="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-filledDefault css-1mywu95-MuiButtonBase-root-MuiChip-root"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="button"
-        tabIndex={0}
-      >
-        <span
-          className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-        >
-          Option2
-        </span>
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-deleteIcon MuiChip-deleteIconMedium MuiChip-deleteIconColorDefault MuiChip-deleteIconFilledColorDefault css-i4bv87-MuiSvgIcon-root"
-          data-testid="CancelIcon"
-          focusable="false"
-          onClick={[Function]}
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </div>
-      <div
-        className="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-filledDefault css-1mywu95-MuiButtonBase-root-MuiChip-root"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="button"
-        tabIndex={0}
-      >
-        <span
-          className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-        >
           Test
         </span>
         <svg
@@ -1428,52 +1288,6 @@ exports[`Filters component > matches the snapshot with one active filter 1`] = `
       </div>
     </div>
   </div>
-  <hr
-    className="MuiDivider-root MuiDivider-fullWidth css-1b008ma-MuiDivider-root"
-  />
-  <div
-    className="MuiStack-root css-1jv2z0n-MuiStack-root"
-  >
-    <div
-      className="MuiStack-root css-1xvxq01-MuiStack-root"
-    >
-      <div
-        className="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-filledDefault css-1mywu95-MuiButtonBase-root-MuiChip-root"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="button"
-        tabIndex={0}
-      >
-        <span
-          className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-        >
-          Option1
-        </span>
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-deleteIcon MuiChip-deleteIconMedium MuiChip-deleteIconColorDefault MuiChip-deleteIconFilledColorDefault css-i4bv87-MuiSvgIcon-root"
-          data-testid="CancelIcon"
-          focusable="false"
-          onClick={[Function]}
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </div>
-    </div>
-  </div>
 </div>
 `;
 
@@ -1868,43 +1682,7 @@ exports[`Filters component > matches the snapshot with one active filter and a r
   >
     <div
       className="MuiStack-root css-1xvxq01-MuiStack-root"
-    >
-      <div
-        className="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-deletable MuiChip-deletableColorDefault MuiChip-filledDefault css-1mywu95-MuiButtonBase-root-MuiChip-root"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="button"
-        tabIndex={0}
-      >
-        <span
-          className="MuiChip-label MuiChip-labelMedium css-6od3lo-MuiChip-label"
-        >
-          Option1
-        </span>
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-deleteIcon MuiChip-deleteIconMedium MuiChip-deleteIconColorDefault MuiChip-deleteIconFilledColorDefault css-i4bv87-MuiSvgIcon-root"
-          data-testid="CancelIcon"
-          focusable="false"
-          onClick={[Function]}
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
-          />
-        </svg>
-      </div>
-    </div>
+    />
     <div>
       Right Content
     </div>

--- a/src/features/filters/components/ActiveFiltersChips.tsx
+++ b/src/features/filters/components/ActiveFiltersChips.tsx
@@ -16,7 +16,9 @@ export const ActiveFilterChips: React.FC<ActiveFilterChips> = ({
   onResetActiveFilters,
   rightContent,
 }) => {
-  if (activeFilters.length <= 0 && !rightContent) return null
+  const visibleFilters = activeFilters.filter(({ type }) => type !== 'autocomplete-multiple')
+
+  if (visibleFilters.length <= 0 && !rightContent) return null
 
   const cancelFiltersLabel = getLocalizedValue({
     it: 'Annulla filtri',
@@ -34,7 +36,7 @@ export const ActiveFilterChips: React.FC<ActiveFilterChips> = ({
         justifyContent="space-between"
       >
         <Stack direction="row" flexWrap="wrap" gap={1} alignItems="center" sx={{ width: '100%' }}>
-          {activeFilters.map(({ value, label, type, filterKey }) => (
+          {visibleFilters.map(({ value, label, type, filterKey }) => (
             <Chip
               key={value}
               label={label}

--- a/src/features/filters/components/AutocompleteBaseFilterField.tsx
+++ b/src/features/filters/components/AutocompleteBaseFilterField.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { AutocompleteProps } from '@mui/material'
-import { Autocomplete, Paper, TextField } from '@mui/material'
+import { Autocomplete, Paper, Stack, TextField } from '@mui/material'
 import { getLocalizedValue } from '../../../utils/common.utils'
 import type { FilterOption } from '../filters.types'
 
@@ -14,7 +14,15 @@ type AutocompleteBaseFilterFieldProps<Multiple extends boolean> = Omit<
   | 'size'
   | 'renderInput'
   | 'onInputChange'
-> & { label: string; onInputChange?: (value: string) => void }
+> & {
+  label: string
+  onInputChange?: (value: string) => void
+  /**
+   * Optional content prepended to the input's endAdornment (before the dropdown arrow).
+   * Used by `AutocompleteMultipleFilterField` to render the count chip in `count-chip` variant.
+   */
+  endAdornmentExtra?: React.ReactNode
+}
 
 export const AutocompleteBaseFilterField = <Multiple extends boolean>(
   props: AutocompleteBaseFilterFieldProps<Multiple>
@@ -24,9 +32,11 @@ export const AutocompleteBaseFilterField = <Multiple extends boolean>(
     en: 'No results',
   })
 
+  const { endAdornmentExtra: _endAdornmentExtra, ...autocompleteProps } = props
+
   return (
     <Autocomplete<FilterOption, Multiple, true, false>
-      {...props}
+      {...autocompleteProps}
       onInputChange={(_, value) => props?.onInputChange?.(value)}
       isOptionEqualToValue={(option, { value }) => option.value === value}
       noOptionsText={noOptionsText}
@@ -46,7 +56,22 @@ export const AutocompleteBaseFilterField = <Multiple extends boolean>(
         props.onChange?.(event, data, reason)
       }}
       renderInput={(params) => {
-        return <TextField variant="outlined" {...params} label={props.label} />
+        const endAdornment = props.endAdornmentExtra ? (
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            {props.endAdornmentExtra}
+            {params.InputProps.endAdornment}
+          </Stack>
+        ) : (
+          params.InputProps.endAdornment
+        )
+        return (
+          <TextField
+            variant="outlined"
+            {...params}
+            label={props.label}
+            InputProps={{ ...params.InputProps, endAdornment }}
+          />
+        )
       }}
     />
   )

--- a/src/features/filters/components/AutocompleteMultipleFilterField.tsx
+++ b/src/features/filters/components/AutocompleteMultipleFilterField.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Checkbox } from '@mui/material'
+import { Checkbox, Chip } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 import type {
   AutocompleteFilterFieldOptions,
   FilterFieldCommonProps,
@@ -16,10 +17,11 @@ export const AutocompleteMultipleFilterField: React.FC<FilterFieldCommonProps> =
 }) => {
   const field = _field as AutocompleteFilterFieldOptions
   const filterKey = field.name
+  const selected = (value as FilterOption[]) ?? []
 
   const debounceRef = React.useRef<NodeJS.Timeout>()
 
-  const handleAutocompleteMultipleChange = (data: FilterFieldsValues['string']) => {
+  const commit = (data: FilterFieldsValues['string']) => {
     onFieldsValuesChange(filterKey, data)
     clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(
@@ -28,24 +30,39 @@ export const AutocompleteMultipleFilterField: React.FC<FilterFieldCommonProps> =
     )
   }
 
+  const countChip =
+    selected.length > 0 ? (
+      <Chip
+        size="small"
+        color="primary"
+        label={selected.length}
+        onDelete={(e) => {
+          e.stopPropagation()
+          commit([])
+        }}
+        deleteIcon={<CloseIcon />}
+      />
+    ) : null
+
   return (
     <AutocompleteBaseFilterField<true>
       multiple
       label={field.label}
-      value={value as FilterOption[]}
+      value={selected}
       options={field.options}
       disableCloseOnSelect
+      endAdornmentExtra={countChip}
       onInputChange={field?.onTextInputChange}
       onChange={(_, data) => {
-        handleAutocompleteMultipleChange(data)
+        commit(data)
       }}
-      renderOption={(props, option, { selected }) => {
+      renderOption={(props, option, { selected: isSelected }) => {
         const label = option.label
         if (!label) return null
 
         return (
           <li {...props}>
-            <Checkbox key={option.value} checked={selected} name={label} />
+            <Checkbox key={option.value} checked={isSelected} name={label} />
             {label}
           </li>
         )


### PR DESCRIPTION
## 🔗 Issue
[PIN-9840](https://pagopa.atlassian.net/browse/PIN-9840) — `[FND] - Componente AutoComplete`

> **Note**: this PR builds on top of [PIN-7358](https://pagopa.atlassian.net/browse/PIN-7358) (filters redesign, branch `feature/PIN-7358_filters-redesign`). It should be reviewed and merged **after** PIN-7358 is finalized. See the Prerequisite section below.

## 📝 Description / Context
The current multi-select filter field (`autocomplete-multiple`) renders one removable `Chip` per selection both **inside** the input (making it grow vertically) and as a row of chips **under** the fields. This hurts accessibility and clashes with the new design direction.

This PR explores the feasibility of a redesign where multi-select fields stay compact, showing a single chip with the selection count inside the input itself (see mockup attached to the Jira ticket). After selecting options the user sees only the count + a close icon to clear all, not a wall of removable tags.

This PR is opened as **draft** to drive the discussion with the design team before finalizing pixel-level details.

## 🛠 List of changes
- `AutocompleteMultipleFilterField`: renders a count `Chip` with a close icon when ≥1 option is selected; `onDelete` clears all selections; `stopPropagation` avoids opening the dropdown.
- `AutocompleteBaseFilterField`: new internal `endAdornmentExtra` slot, prepended to MUI's default `endAdornment` when present. Excluded from the spread to `<Autocomplete>` so it never lands on the DOM.
- `ActiveFiltersChips`: multi-select filters no longer render as removable chips in the summary row (their selection is already shown inside the input). Other filter types (single-value, freetext, datepicker, numeric) still render as chips.
- `Filters.test.tsx` + snapshots updated to reflect the new rendering.

## 🧪 How to test
Link this branch into `pdnd-interop-frontend` (via `pnpm link` or `file:` protocol) — no consumer code change is required, the new behavior is the default for all `autocomplete-multiple` fields.

Suggested pages:
- Consumer → E-service catalog → "Erogato da" filter
- Provider → E-service list
- Any other page using `type: 'autocomplete-multiple'` in `useFilters`

Checklist:
- [ ] Select 1-N options: count chip appears and updates reactively
- [ ] Click the `×` on the count chip: all selections cleared, URL params updated
- [ ] The dropdown does NOT open when clicking the `×`
- [ ] Reload with selections already in URL: count chip reflects the correct count on mount
- [ ] The summary chip row below no longer duplicates multi-select chips
- [ ] Single-select filters (e.g. Notifiche → read/unread) remain unchanged
- [ ] "Annulla filtri" button still clears multi-select too

## ⚠️ Open points to discuss before "Ready for review"
- [ ] **Rollout strategy**: evaluate whether we should introduce an opt-in flag (`variant: 'chips' | 'count-chip'`) to stagger the migration, or proceed with this breaking change as-is. Current implementation takes the second path for simplicity.
- [ ] **Design review**: confirm chip color, size, spacing, close icon, focus/hover states with design against the Jira mockup. Implementation uses placeholder values (`color="primary"`, `size="small"`).
- [ ] **Consumer migration**: list and QA every page in `pdnd-interop-frontend` (and any other commons consumer) declaring an `autocomplete-multiple` filter. No API change required, visual regression testing advisable.
- [ ] **Versioning**: breaking visual change — agree on semver bump. Natural choice is a major release (`1.x.x → 2.0.0`); alternatively a minor with the opt-in flag mentioned above.
- [ ] **Accessibility**: the Jira ticket mentions the current component is not fully accessible. Verify aria-label on the clear chip, keyboard navigation (Escape closes dropdown, Backspace does not remove selections), visible focus ring in the filled state, screen-reader announcement of the count.

## 📎 Prerequisite
This PR is a follow-up / evolution of [PIN-7358](https://pagopa.atlassian.net/browse/PIN-7358) (branch `feature/PIN-7358_filters-redesign`). Merge order should be:
1. PIN-7358 gets reviewed, the filter-applied issues already flagged there get addressed, then merged into `develop`.
2. This branch gets rebased on top of the updated `develop`.
3. Any interaction between `hasSubmitButton` (introduced by PIN-7358) and the count-chip UX introduced here is resolved during the rebase.

## 🖼️ Pictures

<img width="997" height="638" alt="Screenshot 2026-04-21 alle 10 12 05" src="https://github.com/user-attachments/assets/143d76bd-aeed-421c-aadc-156e7a524bf1" />

<img width="1333" height="619" alt="Screenshot 2026-04-21 alle 10 12 15" src="https://github.com/user-attachments/assets/6772960c-d4dd-4606-8187-79ce26f9c274" />

<img width="1330" height="628" alt="Screenshot 2026-04-21 alle 10 12 30" src="https://github.com/user-attachments/assets/848ba928-4cff-4f5b-af53-5e20abddd6f7" />


[PIN-9840]: https://pagopa.atlassian.net/browse/PIN-9840
[PIN-7358]: https://pagopa.atlassian.net/browse/PIN-7358