### PR TITLE
feature: change InformationContainer label color (PIN-9694)

### DIFF
--- a/src/components/InformationContainer.tsx
+++ b/src/components/InformationContainer.tsx
@@ -37,7 +37,11 @@ export function InformationContainer({
       {...props}
     >
       <Box sx={{ flexShrink: 0, maxWidth: direction === 'column' ? 'none' : '200px', flex: 1 }}>
-        <Typography sx={{ mt: copyToClipboard ? 1 : undefined }} variant="body2">
+        <Typography
+          sx={{ mt: copyToClipboard ? 1 : undefined }}
+          variant="body2"
+          color={'text.secondary'}
+        >
           {label}
         </Typography>
         {labelDescription && (

--- a/src/components/__tests__/__snapshots__/InformationContainer.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/InformationContainer.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`InformationContainer component > Render correctly with JSX as content 1
     className="MuiBox-root css-iuqs4u"
   >
     <p
-      className="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
     >
       test-title
     </p>
@@ -47,7 +47,7 @@ exports[`InformationContainer component > Render correctly with column direction
     className="MuiBox-root css-1pdb85g"
   >
     <p
-      className="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
     >
       test-title
     </p>
@@ -76,7 +76,7 @@ exports[`InformationContainer component > Render correctly with content as tring
     className="MuiBox-root css-iuqs4u"
   >
     <p
-      className="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
     >
       test-title
     </p>
@@ -113,7 +113,7 @@ exports[`InformationContainer component > Render correctly with copy to clipboar
     className="MuiBox-root css-iuqs4u"
   >
     <p
-      className="MuiTypography-root MuiTypography-body2 css-1xwhmis-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-body2 css-1i1l7u0-MuiTypography-root"
     >
       test-title
     </p>
@@ -181,7 +181,7 @@ exports[`InformationContainer component > Renders correctly 1`] = `
     className="MuiBox-root css-iuqs4u"
   >
     <p
-      className="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+      className="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
     >
       test-title
     </p>


### PR DESCRIPTION
## Jira Issue
[PIN-9694](https://pagopa.atlassian.net/browse/PIN-9694)

## Context/Why
**InformationContainer style**

## Key Changes
- Change information container label color according to the design
- Update test snapshot

## Screenshots

<img width="1318" height="753" alt="Screenshot 2026-07-09 at 11 00 29" src="https://github.com/user-attachments/assets/d8645627-1131-4b00-ac4e-c409fa95198a" />


[PIN-9694]: https://pagopa.atlassian.net/browse/PIN-9694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ